### PR TITLE
#14 - Add proper support for string starts/ends operators

### DIFF
--- a/src/main/java/com/intuit/graphql/filter/visitors/JpaSpecificationExpressionVisitor.java
+++ b/src/main/java/com/intuit/graphql/filter/visitors/JpaSpecificationExpressionVisitor.java
@@ -105,7 +105,7 @@ public class JpaSpecificationExpressionVisitor<T> implements ExpressionVisitor<S
     @Override
     public Specification<T> visitBinaryExpression(BinaryExpression binaryExpression, Specification<T> data) {
 
-        Specification<T> specification = new Specification<T>() {
+        return new Specification<T>() {
             @Override
             public Predicate toPredicate(Root<T> root, CriteriaQuery<?> criteriaQuery, CriteriaBuilder
                                                                             criteriaBuilder) {
@@ -118,7 +118,13 @@ public class JpaSpecificationExpressionVisitor<T> implements ExpressionVisitor<S
                 switch (binaryExpression.getOperator()) {
                     /* String operations.*/
                     case STARTS:
+                        predicate = criteriaBuilder.like(path, operandValue.value() + "%");
+                        break;
+
                     case ENDS:
+                        predicate = criteriaBuilder.like(path, "%" + operandValue.value());
+                        break;
+
                     case CONTAINS:
                         predicate = criteriaBuilder.like(path, "%" + operandValue.value() + "%");
                         break;
@@ -159,7 +165,6 @@ public class JpaSpecificationExpressionVisitor<T> implements ExpressionVisitor<S
                 return predicate;
             }
         };
-        return specification;
     }
 
     /**

--- a/src/main/java/com/intuit/graphql/filter/visitors/SQLExpressionVisitor.java
+++ b/src/main/java/com/intuit/graphql/filter/visitors/SQLExpressionVisitor.java
@@ -162,7 +162,11 @@ public class SQLExpressionVisitor implements ExpressionVisitor<String> {
         Operator operator = operatorStack.pop();
         List<? extends Comparable> expressionValues  = value.getValues();
 
-        if (operator == Operator.CONTAINS || operator == Operator.STARTS || operator == Operator.ENDS ) {
+        if (operator == Operator.STARTS) {
+            expressionBuilder.append("'").append(expressionValues.get(0)).append("%").append("'");
+        } else if (operator == Operator.ENDS) {
+            expressionBuilder.append("'").append("%").append(expressionValues.get(0)).append("'");
+        } else if (operator == Operator.CONTAINS) {
             expressionBuilder.append("'").append("%").append(expressionValues.get(0)).append("%").append("'");
         } else if(operator == Operator.BETWEEN)  {
             expressionBuilder.append("'").append(expressionValues.get(0)).append("'")

--- a/src/test/java/com/intuit/graphql/filter/common/TestConstants.java
+++ b/src/test/java/com/intuit/graphql/filter/common/TestConstants.java
@@ -220,4 +220,31 @@ public class TestConstants {
             "    lastName\n" +
             "  }\n" +
             "}";
+
+    public static final String FIRST_NAME_STARTS = "{\n" +
+            "  searchEmployees(filter: {\n" +
+            "    firstName : {starts: \"Sa\"}\n" +
+            "  }) {\n" +
+            "    firstName\n" +
+            "    lastName\n" +
+            "  }\n" +
+            "}";
+    public static final String FIRST_NAME_CONTAINS = "{\n" +
+            "  searchEmployees(filter: {\n" +
+            "    firstName : {contains: \"ura\"}\n" +
+            "  }) {\n" +
+            "    firstName\n" +
+            "    lastName\n" +
+            "  }\n" +
+            "}";
+
+    public static final String FIRST_NAME_ENDS = "{\n" +
+            "  searchEmployees(filter: {\n" +
+            "    firstName : {ends: \"bh\"}\n" +
+            "  }) {\n" +
+            "    firstName\n" +
+            "    lastName\n" +
+            "  }\n" +
+            "}";
+
 }

--- a/src/test/java/com/intuit/graphql/filter/visitors/SQLExpressionTest.java
+++ b/src/test/java/com/intuit/graphql/filter/visitors/SQLExpressionTest.java
@@ -173,4 +173,32 @@ public class SQLExpressionTest extends BaseFilterExpressionTest {
 
         Assert.assertEquals(expectedExpression,getEmployeeDataFetcher().getSqlExpression());
     }
+
+    @Test
+    public void compoundFilterExpressionWithStarts() {
+        ExecutionResult result = getGraphQL().execute(TestConstants.FIRST_NAME_STARTS);
+
+        String expectedExpression = "WHERE (empFirstName LIKE 'Sa%')";
+
+        Assert.assertEquals(expectedExpression,getEmployeeDataFetcher().getSqlExpression());
+    }
+
+    @Test
+    public void compoundFilterExpressionWithContains() {
+        ExecutionResult result = getGraphQL().execute(TestConstants.FIRST_NAME_CONTAINS);
+
+        String expectedExpression = "WHERE (empFirstName LIKE '%ura%')";
+
+        Assert.assertEquals(expectedExpression,getEmployeeDataFetcher().getSqlExpression());
+    }
+
+    @Test
+    public void compoundFilterExpressionWithEnds() {
+        ExecutionResult result = getGraphQL().execute(TestConstants.FIRST_NAME_ENDS);
+
+        String expectedExpression = "WHERE (empFirstName LIKE '%bh')";
+
+        Assert.assertEquals(expectedExpression,getEmployeeDataFetcher().getSqlExpression());
+    }
+
 }

--- a/src/test/resources/schema.graphql
+++ b/src/test/resources/schema.graphql
@@ -29,7 +29,9 @@ input EmployeeFilter {
 # Define String expression
 input StringExpression {
    equals: String
+   starts: String
    contains: String
+   ends: String
    in: [String!]
 }
 


### PR DESCRIPTION
<!-- !************* PLEASE READ COMPLETELY *************! 

Thanks for contributing! 

Please use following guide for properly describe your contribution. 

Issue Link - add link to Jira, github or any design document which explains reasoning behind this change.
Software engineers can read and understand code and the issue should finilize parts which DOES NOT implemented.
It should explain rationaly and design decisions. 

Brief explanation of a change - explain change from hightlevel details to specifics.
Configuration options, adoption steps and flags needs to be mentionied here.


Will it break existing clients and code in production - simple yes/no answer.
Mostly it speaks about API compatibility, however it is not limited by it alone.
Behavior change as well as impact on dependencies should be reflected here as well. 

-->

**1. Issue Link:** 
https://github.com/intuit/graphql-filter-java/issues/14

**2. Brief explanation of a change:** 
Implement START/END string operators instead of falling through CONTAINS.

**3. Will it break existing clients and code in production?**
Can possibly be considered a breaking change as behaviour will be more restrictive with this change.