### PR TITLE
Added support for customizing filter field name & value before applying to data source.

### DIFF
--- a/src/main/java/com/intuit/graphql/filter/ast/ExpressionValue.java
+++ b/src/main/java/com/intuit/graphql/filter/ast/ExpressionValue.java
@@ -17,20 +17,18 @@ package com.intuit.graphql.filter.ast;
 
 import com.intuit.graphql.filter.visitors.ExpressionVisitor;
 
-import java.util.List;
-
 /**
  * Represents an expression value node
  * in the expression tree.
  *
  * @author sjaiswal
  */
-public class ExpressionValue<V extends Comparable> implements Expression {
+public class ExpressionValue<V> implements Expression {
 
-    private List<V> values;
+    private V value;
 
-    public ExpressionValue(List<V> values) {
-        this.values = values;
+    public ExpressionValue(V value) {
+        this.value = value;
     }
 
     /**
@@ -40,13 +38,20 @@ public class ExpressionValue<V extends Comparable> implements Expression {
     @Override
     public String infix() {
         StringBuilder infix = new StringBuilder("");
-        if (values != null && values.size() > 0) {
-            for (V value : values) {
-                infix.append(value.toString()).append(",");
+        String result = null;
+        if (value != null) {
+            if (value instanceof Iterable) {
+                Iterable<V> vals = (Iterable<V>) value;
+                for (V val : vals) {
+                    infix.append(value.toString()).append(",");
+                }
+                result = infix.toString() == "" ? "" : infix.substring(0, infix.length()-1);
+            } else {
+                infix.append(value);
+                result = infix.toString();
             }
-
         }
-        return infix.toString() == "" ? "" : infix.substring(0, infix.length()-1);
+        return result;
     }
 
     /**
@@ -54,11 +59,7 @@ public class ExpressionValue<V extends Comparable> implements Expression {
      * @return
      */
     public V value() {
-        return values.get(0);
-    }
-
-    public List<V> getValues() {
-        return values;
+        return value;
     }
 
     /**

--- a/src/main/java/com/intuit/graphql/filter/client/ExpressionVisitorFactory.java
+++ b/src/main/java/com/intuit/graphql/filter/client/ExpressionVisitorFactory.java
@@ -39,18 +39,19 @@ class ExpressionVisitorFactory {
      * @return
      */
     static ExpressionVisitor getExpressionVisitor(ExpressionFormat format,
-                                                         Map<String, String> fieldMap) {
-        ExpressionVisitor expressionVisitor = new InfixExpressionVisitor(fieldMap);
+                                                  Map<String, String> fieldMap,
+                                                  FieldValueTransformer fieldValueTransformer) {
+        ExpressionVisitor expressionVisitor = new InfixExpressionVisitor(fieldMap, fieldValueTransformer);
         if (format != null) {
             switch (format) {
                 case INFIX:
-                    expressionVisitor = new InfixExpressionVisitor(fieldMap);
+                    expressionVisitor = new InfixExpressionVisitor(fieldMap, fieldValueTransformer);
                     break;
                 case SQL:
-                    expressionVisitor =  new SQLExpressionVisitor(fieldMap);
+                    expressionVisitor =  new SQLExpressionVisitor(fieldMap, fieldValueTransformer);
                     break;
                 case JPA:
-                    expressionVisitor = new JpaSpecificationExpressionVisitor(fieldMap);
+                    expressionVisitor = new JpaSpecificationExpressionVisitor(fieldMap, fieldValueTransformer);
             }
         }
         return expressionVisitor;

--- a/src/main/java/com/intuit/graphql/filter/client/FieldValuePair.java
+++ b/src/main/java/com/intuit/graphql/filter/client/FieldValuePair.java
@@ -1,0 +1,51 @@
+/*
+  Copyright 2021 Intuit Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+package com.intuit.graphql.filter.client;
+
+/**
+ * Field value pair for providing custom
+ * field name and value for customizing
+ * filter field.
+ *
+ * @author sjaiswal on 11/18/21
+ */
+public class FieldValuePair <V> {
+    private String fieldName;
+    private V value;
+
+    public FieldValuePair(String fieldName, V value) {
+        this.fieldName = fieldName;
+        this.value = value;
+    }
+
+    /**
+     * Returns the field name.
+     *
+     * @return
+     */
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    /**
+     * Returns the field value.
+     * @return
+     */
+    public V getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/intuit/graphql/filter/client/FieldValueTransformer.java
+++ b/src/main/java/com/intuit/graphql/filter/client/FieldValueTransformer.java
@@ -1,0 +1,42 @@
+/*
+  Copyright 2021 Intuit Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+package com.intuit.graphql.filter.client;
+
+/**
+ * Transformer interface for customizing
+ * filter field and value.
+ *
+ * @author sjaiswal on 11/18/21
+ */
+public interface FieldValueTransformer {
+
+    /**
+     * Returns a new field name for the given field name.
+     * @param fieldName
+     * @return
+     */
+    public String transformField(String fieldName);
+
+    /**
+     * Returns an instance of FieldValuePair.
+     * @param fieldName
+     * @param value
+     * @return
+     */
+    public FieldValuePair<? extends Object> transformValue(String fieldName, Object value);
+}
+

--- a/src/main/java/com/intuit/graphql/filter/client/FilterExpression.java
+++ b/src/main/java/com/intuit/graphql/filter/client/FilterExpression.java
@@ -34,11 +34,13 @@ public class FilterExpression {
     private Field field;
     private Map<String,String> fieldMap;
     private Expression expressionAst;
+    private FieldValueTransformer fieldValueTransformer;
 
     private FilterExpression(FilterExpressionBuilder expressionBuilder) {
         this.field = expressionBuilder.field;
         this.fieldMap = expressionBuilder.fieldMap;
         this.expressionAst = expressionBuilder.expressionAst;
+        this.fieldValueTransformer = expressionBuilder.fieldValueTransformer;
     }
 
     /**
@@ -52,6 +54,7 @@ public class FilterExpression {
         private Expression expressionAst;
         private Map args;
         private final String FILTER_ARG = "filter";
+        private FieldValueTransformer fieldValueTransformer;
 
         private FilterExpressionBuilder () {
             fieldMap = new HashMap<>();
@@ -74,6 +77,11 @@ public class FilterExpression {
 
         public FilterExpressionBuilder args(Map filterArgs) {
             this.args = filterArgs;
+            return this;
+        }
+
+        public FilterExpressionBuilder transform(FieldValueTransformer fieldValueTransformer) {
+            this.fieldValueTransformer = fieldValueTransformer;
             return this;
         }
 
@@ -105,7 +113,7 @@ public class FilterExpression {
         if (expressionAst == null) {
             throw new InvalidFilterException("Missing or invalid filter arguments");
         }
-        ExpressionVisitor<T> expressionVisitor = ExpressionVisitorFactory.getExpressionVisitor(format, fieldMap);
+        ExpressionVisitor<T> expressionVisitor = ExpressionVisitorFactory.getExpressionVisitor(format, fieldMap, fieldValueTransformer);
         return expressionVisitor.expression(expressionAst);
     }
 }

--- a/src/main/java/com/intuit/graphql/filter/client/FilterExpressionParser.java
+++ b/src/main/java/com/intuit/graphql/filter/client/FilterExpressionParser.java
@@ -70,17 +70,18 @@ class FilterExpressionParser {
                     case "BINARY":
                         BinaryExpression binaryExpression = new BinaryExpression();
                         binaryExpression.setOperator(Operator.getOperator(key));
-                        List<Comparable> expressionValues = new ArrayList<>();
                         if (entry.getValue() instanceof Collection) {
+                            List<Comparable> expressionValues = new ArrayList<>();
                             List<Comparable> operandValues = (List<Comparable>) entry.getValue();
                             for (Comparable value : operandValues) {
                                 expressionValues.add(convertIfDate(value));
                             }
+                            ExpressionValue<List> expressionValue = new ExpressionValue(expressionValues);
+                            binaryExpression.setRightOperand(expressionValue);
                         } else {
-                            expressionValues.add(convertIfDate((Comparable) entry.getValue()));
+                            ExpressionValue<Comparable> expressionValue = new ExpressionValue<>(convertIfDate((Comparable) entry.getValue()));
+                            binaryExpression.setRightOperand(expressionValue);
                         }
-                        ExpressionValue<Comparable> expressionValue = new ExpressionValue(expressionValues);
-                        binaryExpression.setRightOperand(expressionValue);
                         expression = binaryExpression;
                         break;
 


### PR DESCRIPTION
**1. Issue Link:** 
N/A: It is a new feature.

**2. Brief explanation of a change:** 
This feature will allow developers to add custom logic to transform filter field names & values before they get applied to underlying data source. With this filter field name & values can be decoupled from data source column name.

**How to use:**
```
                FilterExpression.FilterExpressionBuilder builder = FilterExpression.newFilterExpressionBuilder();
                FilterExpression filterExpression = builder.args(dataFetchingEnvironment.getArguments())
                        .transform(new FieldValueTransformer() {
                            @Override
                            public String transformField(String fieldName) {
                                if ("firstName".equals(fieldName)) {
                                    return "givenName";
                                }
                                return fieldName;
                            }

                            @Override
                            public FieldValuePair<? extends Object> transformValue(String fieldName, Object value) {
                                if ("status".equals(fieldName) && "fullTime".equals(value.toString())) {
                                    return new FieldValuePair<>(fieldName, "FT");
                                }
                                return new FieldValuePair<>(fieldName, value);
                            }
                        })
                        .build();

                Specification<EmployeeEntity> specification = filterExpression.getExpression(ExpressionFormat.JPA);
```

**3. Will it break existing clients and code in production?**
No.
