### PR TITLE
Add null equality to EQ JPA expression visitor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.intuit.graphql</groupId>
   <artifactId>graphql-filter-java</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.0-SNAPSHOT</version>
 
   <name>${project.artifactId}</name>
   <description>A java library to transform graphql filter into database filter</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.intuit.graphql</groupId>
   <artifactId>graphql-filter-java</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.1</version>
 
   <name>${project.artifactId}</name>
   <description>A java library to transform graphql filter into database filter</description>

--- a/src/main/java/com/intuit/graphql/filter/visitors/JpaSpecificationExpressionVisitor.java
+++ b/src/main/java/com/intuit/graphql/filter/visitors/JpaSpecificationExpressionVisitor.java
@@ -153,7 +153,11 @@ public class JpaSpecificationExpressionVisitor<T> implements ExpressionVisitor<S
                         break;
 
                     case EQ:
-                        predicate = criteriaBuilder.equal(path, operandValue.value());
+                        if (operandValue.value() == null) {
+                            predicate = criteriaBuilder.isNull(path);
+                        } else {
+                            predicate = criteriaBuilder.equal(path, operandValue.value());
+                        }
                         break;
 
                     case GT:


### PR DESCRIPTION
<!-- !************* PLEASE READ COMPLETELY *************! 

Thanks for contributing! 

Please use following guide for properly describe your contribution. 

Issue Link - add link to Jira, github or any design document which explains reasoning behind this change.
Software engineers can read and understand code and the issue should finilize parts which DOES NOT implemented.
It should explain rationaly and design decisions. 

Brief explanation of a change - explain change from hightlevel details to specifics.
Configuration options, adoption steps and flags needs to be mentionied here.


Will it break existing clients and code in production - simple yes/no answer.
Mostly it speaks about API compatibility, however it is not limited by it alone.
Behavior change as well as impact on dependencies should be reflected here as well. 

-->

**1. Issue Link:** 
https://github.com/intuit/graphql-filter-java/issues/23

**2. Brief explanation of a change:** 
Instead of assuming all values of `eq` to use `criteriaBuilder.equal`, if the value is `null`, we want to use `criteriaBuilder.isNull` instead to create the right specification.

**3. Will it break existing clients and code in production?**
No