### PR TITLE
Added Elasticsearch expression support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,12 @@
 
     <dependency>
       <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-elasticsearch</artifactId>
+      <version>${spring.data.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.data</groupId>
       <artifactId>spring-data-jpa</artifactId>
       <version>${spring.data.version}</version>
     </dependency>

--- a/src/main/java/com/intuit/graphql/filter/client/ExpressionFormat.java
+++ b/src/main/java/com/intuit/graphql/filter/client/ExpressionFormat.java
@@ -25,7 +25,8 @@ public enum ExpressionFormat {
     SQL("SQL"),
     INFIX("INFIX"),
     JPA("JPA"),
-    MONGO("MONGO");
+    MONGO("MONGO"),
+    ELASTICSEARCH("ELASTICSEARCH");
 
     private String type;
     ExpressionFormat(String type) {

--- a/src/main/java/com/intuit/graphql/filter/client/ExpressionVisitorFactory.java
+++ b/src/main/java/com/intuit/graphql/filter/client/ExpressionVisitorFactory.java
@@ -15,6 +15,7 @@
  */
 package com.intuit.graphql.filter.client;
 
+import com.intuit.graphql.filter.visitors.ElasticsearchCriteriaExpressionVisitor;
 import com.intuit.graphql.filter.visitors.ExpressionVisitor;
 import com.intuit.graphql.filter.visitors.InfixExpressionVisitor;
 import com.intuit.graphql.filter.visitors.JpaSpecificationExpressionVisitor;
@@ -56,6 +57,10 @@ class ExpressionVisitorFactory {
                     break;
                 case MONGO:
                     expressionVisitor =  new MongoCriteriaExpressionVisitor(fieldMap, fieldValueTransformer);
+                    break;
+                case ELASTICSEARCH:
+                    expressionVisitor = new ElasticsearchCriteriaExpressionVisitor(fieldMap, fieldValueTransformer);
+                    break;
             }
         }
         return expressionVisitor;

--- a/src/main/java/com/intuit/graphql/filter/visitors/ElasticsearchCriteriaExpressionVisitor.java
+++ b/src/main/java/com/intuit/graphql/filter/visitors/ElasticsearchCriteriaExpressionVisitor.java
@@ -1,0 +1,224 @@
+/*
+  Copyright 2020 Intuit Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.intuit.graphql.filter.visitors;
+
+import com.intuit.graphql.filter.ast.BinaryExpression;
+import com.intuit.graphql.filter.ast.CompoundExpression;
+import com.intuit.graphql.filter.ast.Expression;
+import com.intuit.graphql.filter.ast.ExpressionField;
+import com.intuit.graphql.filter.ast.ExpressionValue;
+import com.intuit.graphql.filter.ast.UnaryExpression;
+import com.intuit.graphql.filter.client.FieldValuePair;
+import com.intuit.graphql.filter.client.FieldValueTransformer;
+import org.springframework.data.elasticsearch.core.query.Criteria;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class is responsible for traversing the expression tree and generating a compound elasticsearch {@link Criteria}
+ * from it with correct precedence order.
+ *
+ * @author Sohan Lal
+ */
+public class ElasticsearchCriteriaExpressionVisitor implements ExpressionVisitor<Criteria> {
+
+    private static final String QUOTE_CHARACTER = "\"";
+
+    private final Map<String, String> fieldMap;
+    private final Deque<String> fieldStack;
+    private final FieldValueTransformer fieldValueTransformer;
+
+    public ElasticsearchCriteriaExpressionVisitor(final Map<String, String> fieldMap, final FieldValueTransformer fieldValueTransformer) {
+        this.fieldMap = fieldMap;
+        this.fieldStack = new ArrayDeque<>();
+        this.fieldValueTransformer = fieldValueTransformer;
+    }
+
+    /**
+     * Returns the elastic criteria from the expression tree.
+     *
+     * @param expression The {@link Expression} instance.
+     * @return A criteria to be used with {@link org.springframework.data.elasticsearch.core.query.Criteria}.
+     */
+    @Override
+    public Criteria expression(final Expression expression) {
+        Criteria criteria = null;
+        if (expression != null) {
+            criteria = expression.accept(this, null);
+        }
+        return criteria;
+    }
+
+    /**
+     * Handles the processing of compound expression node.
+     *
+     * @param compoundExpression Contains compound expression.
+     * @param data               Buffer for storing processed data.
+     * @return Data of processed node.
+     */
+    @Override
+    public Criteria visitCompoundExpression(final CompoundExpression compoundExpression, final Criteria data) {
+        Criteria result = null;
+        switch (compoundExpression.getOperator()) {
+            /* Logical operations.*/
+            case AND:
+                Criteria left = compoundExpression.getLeftOperand().accept(this, null);
+                Criteria right = compoundExpression.getRightOperand().accept(this, null);
+                result = left.and(right);
+                break;
+
+            case OR:
+                left = compoundExpression.getLeftOperand().accept(this, null);
+                right = compoundExpression.getRightOperand().accept(this, null);
+                result = left.or(right);
+                break;
+        }
+        return result;
+    }
+
+    /**
+     * Handles the processing of binary expression node.
+     *
+     * @param binaryExpression Contains binary expression.
+     * @param data             Buffer for storing processed data.
+     * @return Data of processed node.
+     */
+    @Override
+    public Criteria visitBinaryExpression(final BinaryExpression binaryExpression, final Criteria data) {
+        Criteria criteria = null;
+        final String fieldName = mappedFieldName(binaryExpression.getLeftOperand().infix());
+        ExpressionValue<? extends Comparable> operandValue = (ExpressionValue<? extends Comparable>) binaryExpression.getRightOperand();
+        operandValue = getTransformedValue(operandValue);
+
+        switch (binaryExpression.getOperator()) {
+            /* String operations.*/
+            case STARTS:
+                criteria = Criteria.where(fieldName).startsWith(operandValue.value().toString());
+                break;
+
+            case ENDS:
+                criteria = Criteria.where(fieldName).endsWith(operandValue.value().toString());
+                break;
+
+            case CONTAINS:
+                criteria = Criteria.where(fieldName).contains(operandValue.value().toString());
+                break;
+
+            case EQUALS:
+                criteria = Criteria.where(fieldName).expression(QUOTE_CHARACTER + operandValue.value().toString() + QUOTE_CHARACTER);
+                break;
+
+            /* Numeric operations.*/
+            case LT:
+                criteria = Criteria.where(fieldName).lessThan(operandValue.value());
+                break;
+
+            case LTE:
+                criteria = Criteria.where(fieldName).lessThanEqual(operandValue.value());
+                break;
+
+            case EQ:
+                criteria = Criteria.where(fieldName).is(operandValue.value());
+                break;
+
+            case GT:
+                criteria = Criteria.where(fieldName).greaterThan(operandValue.value());
+                break;
+
+            case GTE:
+                criteria = Criteria.where(fieldName).greaterThanEqual(operandValue.value());
+                break;
+
+            case IN:
+                List<Comparable> expressionInValues = (List<Comparable>) operandValue.value();
+                criteria = Criteria.where(fieldName).in(expressionInValues);
+                break;
+
+            case BETWEEN:
+                List<Comparable> expressionBetweenValues = (List<Comparable>) operandValue.value();
+                criteria = Criteria.where(fieldName).greaterThanEqual(expressionBetweenValues.get(0)).lessThanEqual(expressionBetweenValues.get(1));
+                break;
+        }
+        return criteria;
+    }
+
+    /**
+     * Handles the processing of unary expression node.
+     *
+     * @param unaryExpression Contains unary expression.
+     * @param data            Buffer for storing processed data.
+     * @return Data of processed node.
+     */
+    @Override
+    public Criteria visitUnaryExpression(final UnaryExpression unaryExpression, final Criteria data) {
+        final Criteria left = unaryExpression.getLeftOperand().accept(this, null);
+        return left.not();
+    }
+
+    /**
+     * Handles the processing of expression field node.
+     *
+     * @param field Contains expression field.
+     * @param data  Buffer for storing processed data.
+     * @return Data of processed node.
+     */
+    @Override
+    public Criteria visitExpressionField(final ExpressionField field, final Criteria data) {
+        /* ExpressionField has been taken care in the Binary expression visitor. */
+        return null;
+    }
+
+    /**
+     * Handles the processing of expression value node.
+     *
+     * @param value Contains expression value.
+     * @param data  Buffer for storing processed data.
+     * @return Data of processed node.
+     */
+    @Override
+    public Criteria visitExpressionValue(final ExpressionValue<? extends Comparable> value, final Criteria data) {
+        /* ExpressionValue has been taken care in the Binary expression visitor. */
+        return null;
+    }
+
+    private String mappedFieldName(final String fieldName) {
+        final String mappedFieldName;
+        if (fieldMap != null && fieldMap.get(fieldName) != null) {
+            mappedFieldName = fieldMap.get(fieldName);
+        } else if (fieldValueTransformer != null && fieldValueTransformer.transformField(fieldName) != null) {
+            mappedFieldName = fieldValueTransformer.transformField(fieldName);
+            fieldStack.push(fieldName); //pushing the field for lookup while visiting value.
+        } else {
+            mappedFieldName = fieldName;
+        }
+        return mappedFieldName;
+    }
+
+    private ExpressionValue getTransformedValue(final ExpressionValue<? extends Comparable> value) {
+        if (!fieldStack.isEmpty() && fieldValueTransformer != null) {
+            final String field = fieldStack.pop(); // pop the field associated with this value.
+            final FieldValuePair fieldValuePair = fieldValueTransformer.transformValue(field, value.value());
+            if (fieldValuePair != null && fieldValuePair.getValue() != null) {
+                return new ExpressionValue(fieldValuePair.getValue());
+            }
+        }
+        return value;
+    }
+
+}

--- a/src/test/java/com/intuit/graphql/filter/common/EmployeeDataFetcher.java
+++ b/src/test/java/com/intuit/graphql/filter/common/EmployeeDataFetcher.java
@@ -34,6 +34,7 @@ public class EmployeeDataFetcher {
     private String sqlExpression;
     private Specification<Object> specification;
     private Criteria mongoCriteria;
+    private org.springframework.data.elasticsearch.core.query.Criteria elasticsearchCriteria;
 
     public EmployeeDataFetcher() {
 
@@ -88,7 +89,6 @@ public class EmployeeDataFetcher {
     }
 
     public DataFetcher searchEmployeesMongo() {
-
         return new DataFetcher() {
             @Override
             public Object get(DataFetchingEnvironment dataFetchingEnvironment) throws Exception {
@@ -97,6 +97,20 @@ public class EmployeeDataFetcher {
                         .args(dataFetchingEnvironment.getArguments())
                         .build();
                 mongoCriteria = filterExpression.getExpression(ExpressionFormat.MONGO);
+                return null;
+            }
+        };
+    }
+
+    public DataFetcher searchEmployeesElasticsearch() {
+        return new DataFetcher() {
+            @Override
+            public Object get(DataFetchingEnvironment dataFetchingEnvironment) throws Exception {
+                FilterExpression.FilterExpressionBuilder builder = FilterExpression.newFilterExpressionBuilder();
+                FilterExpression filterExpression = builder.field(dataFetchingEnvironment.getField())
+                        .args(dataFetchingEnvironment.getArguments())
+                        .build();
+                elasticsearchCriteria = filterExpression.getExpression(ExpressionFormat.ELASTICSEARCH);
                 return null;
             }
         };
@@ -116,6 +130,10 @@ public class EmployeeDataFetcher {
 
     public Criteria getMongoCriteria() {
         return mongoCriteria;
+    }
+
+    public org.springframework.data.elasticsearch.core.query.Criteria getElasticsearchCriteria() {
+        return elasticsearchCriteria;
     }
 
 }

--- a/src/test/java/com/intuit/graphql/filter/visitors/ElasticsearchCriteriaExpressionTest.java
+++ b/src/test/java/com/intuit/graphql/filter/visitors/ElasticsearchCriteriaExpressionTest.java
@@ -1,0 +1,134 @@
+/*
+  Copyright 2020 Intuit Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.intuit.graphql.filter.visitors;
+
+import com.intuit.graphql.filter.common.TestConstants;
+import graphql.ExecutionResult;
+import graphql.scalars.ExtendedScalars;
+import graphql.schema.idl.RuntimeWiring;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.data.elasticsearch.core.query.Criteria;
+
+import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring;
+
+/**
+ * @author Sohan Lal
+ */
+public class ElasticsearchCriteriaExpressionTest extends BaseFilterExpressionTest {
+
+    @Override
+    protected RuntimeWiring buildWiring() {
+        return RuntimeWiring.newRuntimeWiring()
+                .scalar(ExtendedScalars.DateTime)
+                .type(newTypeWiring("Query")
+                        .dataFetcher("searchEmployees", getEmployeeDataFetcher().searchEmployeesElasticsearch()))
+                .build();
+    }
+
+    @Test
+    public void filterExpressionSimple() {
+        getGraphQL().execute(TestConstants.BINARY_FILER);
+
+        final Criteria actualCriteria = getEmployeeDataFetcher().getElasticsearchCriteria();
+        final Criteria expectedCriteria = Criteria.where("firstName").contains("Saurabh");
+
+        Assert.assertEquals(expectedCriteria.toString(), actualCriteria.toString());
+    }
+
+    @Test
+    public void filterExpressionSimpleInt() {
+        getGraphQL().execute(TestConstants.BINARY_FILER_INT);
+
+        final Criteria actualCriteria = getEmployeeDataFetcher().getElasticsearchCriteria();
+        final Criteria expectedCriteria = new Criteria("age").greaterThanEqual(25);
+
+        Assert.assertEquals(expectedCriteria.toString(), actualCriteria.toString());
+    }
+
+    @Test
+    public void filterExpressionWithOR() {
+        ExecutionResult result = getGraphQL().execute(TestConstants.COMPOUND_FILER_WITH_OR);
+
+        final Criteria actualCriteria = getEmployeeDataFetcher().getElasticsearchCriteria();
+        final Criteria expectedCriteria = Criteria.where("firstName").contains("Saurabh")
+                .or(Criteria.where("lastName").expression("\"Jaiswal\""));
+
+        Assert.assertEquals(expectedCriteria.toString(), actualCriteria.toString());
+    }
+
+    @Test
+    public void filterExpressionWithAND() {
+        ExecutionResult result = getGraphQL().execute(TestConstants.COMPOUND_FILER_WITH_AND);
+
+        final Criteria actualCriteria = getEmployeeDataFetcher().getElasticsearchCriteria();
+        final Criteria expectedCriteria = Criteria.where("firstName").contains("Saurabh")
+                .and(Criteria.where("lastName").expression("\"Jaiswal\""));
+
+        Assert.assertEquals(expectedCriteria.toString(), actualCriteria.toString());
+    }
+
+    @Test
+    public void filterExpressionORWithAND() {
+        ExecutionResult result = getGraphQL().execute(TestConstants.COMPOUND_FILER_WITH_OR_AND);
+
+        final Criteria actualCriteria = getEmployeeDataFetcher().getElasticsearchCriteria();
+        final Criteria expectedCriteria = Criteria.where("firstName").contains("Saurabh")
+                .or(Criteria.where("lastName").expression("\"Jaiswal\"")
+                        .and(Criteria.where("age").greaterThanEqual(25)));
+
+        Assert.assertEquals(expectedCriteria.toString(), actualCriteria.toString());
+    }
+
+    @Test
+    public void filterExpressionANDWithOR() {
+        ExecutionResult result = getGraphQL().execute(TestConstants.COMPOUND_FILER_WITH_AND_OR);
+
+        final Criteria actualCriteria = getEmployeeDataFetcher().getElasticsearchCriteria();
+        final Criteria expectedCriteria = Criteria.where("firstName").contains("Saurabh")
+                .and(Criteria.where("lastName").expression("\"Jaiswal\"")
+                        .or(Criteria.where("age").greaterThanEqual(25)));
+
+        Assert.assertEquals(expectedCriteria.toString(), actualCriteria.toString());
+    }
+
+    @Test
+    public void filterExpressionANDWithMultipleOR() {
+        ExecutionResult result = getGraphQL().execute(TestConstants.COMPOUND_FILER_WITH_OR_OR_AND);
+
+        final Criteria actualCriteria = getEmployeeDataFetcher().getElasticsearchCriteria();
+        final Criteria expectedCriteria = Criteria.where("firstName").contains("Saurabh")
+                .or(Criteria.where("lastName").expression("\"Jaiswal\""))
+                .or(Criteria.where("firstName").expression("\"Vinod\"")
+                        .and(Criteria.where("age").greaterThanEqual(30)));
+
+        Assert.assertEquals(expectedCriteria.toString(), actualCriteria.toString());
+    }
+
+    @Test
+    public void filterExpressionORWithMultipleAND() {
+        ExecutionResult result = getGraphQL().execute(TestConstants.COMPOUND_FILER_WITH_AND_AND_OR);
+
+        final Criteria actualCriteria = getEmployeeDataFetcher().getElasticsearchCriteria();
+        final Criteria expectedCriteria = Criteria.where("firstName").contains("Saurabh")
+                .and(Criteria.where("lastName").expression("\"Jaiswal\""))
+                .and(Criteria.where("firstName").expression("\"Vinod\"")
+                        .or(Criteria.where("age").greaterThanEqual(30)));
+
+        Assert.assertEquals(expectedCriteria.toString(), actualCriteria.toString());
+    }
+
+}


### PR DESCRIPTION
**1. Issue Link:** 
#32 

**2. Brief explanation of a change:** 
Added support to create Elasticsearch criteria instance to be able to use graphQL generic filters with MongoDB.

**3. Will it break existing clients and code in production?**
No